### PR TITLE
Adds packer hooks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,34 @@
+---
+name: Bug
+about: A bug or problem with the packer-<insert type>  pre-commit-hook
+labels: bug
+---
+
+<!-- Please provide a general summary of the issue in the Title above -->
+
+# Expected Behavior
+
+<!-- Explain what you expect to happen -->
+
+## Current Behavior
+
+<!-- Explain what actually happens -->
+
+## Steps to Reproduce
+
+<!-- Explain how to reproduce the problem -->
+<!-- If relevant, include code, screenshots or links -->
+
+## Environment
+
+1.) Output of `pre-commit --version`
+
+```sh
+
+```
+
+2.) Any other relevant environment information:
+
+```sh
+
+```

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,6 @@
 ---
 name: Bug
-about: A bug or problem with the packer-<insert type>  pre-commit-hook
+about: A bug or problem with the packer-<insert type> pre-commit-hook
 labels: bug
 ---
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,88 @@
+---
+
+name: Code Quality
+
+on:
+  pull_request:
+
+env:
+  PARENT_ORG: operatehappy
+  META_PATH: dotfiles-org
+  SELF_PATH: repository
+  PYTHON_VERSION: 3.8
+  PYTHON_ARCH: x64
+  PRECOMMIT_CACHE_PATH: ".cache/pre-commit"
+  PRECOMMIT_VERSION: 1.18.3
+  PRECOMMIT_CONFIG: ".pre-commit-config.yaml"
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    name: pre-commit
+
+    steps:
+      - name: Checkout Meta Repository
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.PARENT_ORG }}/${{ env.META_PATH }}
+          ref: master
+          path: ${{ env.META_PATH }}
+          fetch-depth: 1
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: ${{ env.SELF_PATH }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: ${{ env.PYTHON_ARCH }}
+
+      - name: Update and Restore pip Binaries Cache
+        uses: actions/cache@v1
+        id: cache-pip-binaries
+        with:
+          path: "${{ env.pythonLocation }}/bin"
+          key: "pip-binaries-${{ env.PYTHON_VERSION }}-${{ env.PRECOMMIT_VERSION }}"
+
+      - name: Update and Restore pip Packages Cache
+        uses: actions/cache@v1
+        id: cache-pip-packages
+        with:
+          path: "${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages"
+          key: "pip-packages-${{ env.PYTHON_VERSION }}-${{ env.PRECOMMIT_VERSION }}"
+
+      - name: Update and Restore pre-commit Cache
+        uses: actions/cache@v1
+        id: cache-precommit-hooks
+        with:
+          path: "~/${{ env.PRECOMMIT_CACHE_PATH }}"
+          key: ${{ hashFiles(format('{0}/{1}/{2}', github.workspace, env.META_PATH, env.PRECOMMIT_CONFIG )) }}
+
+      - name: Install `pre-commit` via `pip`
+        run: |
+          pip \
+            install "pre-commit==${{ env.PRECOMMIT_VERSION }}"
+        shell: sh
+        if: steps.cache-pip-binaries.outputs.cache-hit != 'true' && steps.cache-pip-packages.outputs.cache-hit != 'true'
+
+      - name: Setup `pre-commit`
+        run: |
+          pre-commit \
+            install \
+              --config "${{ github.workspace }}${{ env.UPSTREAM_REP }}/${{ env.PRECOMMIT_CONFIG }}"
+        shell: sh
+        working-directory: "${{ github.workspace }}/${{ env.SELF_PATH }}"
+        if: steps.cache-precommit.outputs.cache-hit != 'true'
+
+      - name: Run `pre-commit`
+        run: |
+          pre-commit \
+            run \
+              --config "${{ github.workspace }}/${{ env.META_PATH }}/${{ env.PRECOMMIT_CONFIG }}" \
+              --all-files
+        working-directory: "${{ github.workspace }}/${{ env.SELF_PATH }}"
+        shell: sh

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -1,0 +1,18 @@
+---
+
+name: Repository Management
+
+on:
+  pull_request:
+
+jobs:
+  assign-pr-to-author:
+    runs-on: ubuntu-latest
+    name: assign-pr-to-author
+
+    steps:
+      - name: Assign Pull Request to Author
+        uses: technote-space/assign-author@v1
+        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,19 @@
 ---
 
+- id: packer-fix
+  name: Fix Packer template(s) with backwards incompatibilities
+  entry: hashicorp/packer:light fix
+  language: docker_image
+  types: [json]
+  files: ^packer.json$
+  always_run: false
+  verbose: false
+  pass_filenames: true
+  description: Attempts to fix incompatibilities in a template
+  minimum_pre_commit_version: 1.15.0
+
 - id: packer-validate
-  name: Packer validate
+  name: Validate Packer template(s)
   entry: hashicorp/packer:light validate
   language: docker_image
   types: [json]
@@ -15,20 +27,8 @@
     -syntax-only
   ]
 
-- id: packer-fix
-  name: Packer fix
-  entry: hashicorp/packer:light fix
-  language: docker_image
-  types: [json]
-  files: ^packer.json$
-  always_run: false
-  verbose: false
-  pass_filenames: true
-  description: Attempts to fix incompatibilities in a template
-  minimum_pre_commit_version: 1.15.0
-
-- id: packer-fix-and-validate
-  name: Packer fix and validate
+- id: packer-validate-and-fix
+  name: Validate Packer template(s) and fix backwards incompatibilities
   entry: hashicorp/packer:light fix -validate=true
   language: docker_image
   types: [json]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
   types: [json]
   files: ^packer.json$
   always_run: false
+  verbose: false
   pass_filenames: true
   description: Validates a template against builders, provisioners
   minimum_pre_commit_version: 1.15.0
@@ -21,6 +22,7 @@
   types: [json]
   files: ^packer.json$
   always_run: false
+  verbose: false
   pass_filenames: true
   description: Attempts to fix incompatibilities in a template
   minimum_pre_commit_version: 1.15.0
@@ -32,6 +34,7 @@
   types: [json]
   files: ^packer.json$
   always_run: false
+  verbose: false
   pass_filenames: true
   description: Validates and attempts to fix incompatibilities in a template
   minimum_pre_commit_version: 1.15.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,18 +1,23 @@
 ---
 
-- id: packer-fix
-  name: Fix Packer template(s) with backwards incompatibilities
-  entry: hashicorp/packer:light fix
-  language: docker_image
+-
+  id: packer-validate
+  name: Validate Packer template(s)
+  entry: packer validate
+  language: system
   types: [json]
   files: ^packer.json$
   always_run: false
   verbose: false
   pass_filenames: true
-  description: Attempts to fix incompatibilities in a template
+  description: Validates a template against builders, provisioners
   minimum_pre_commit_version: 1.15.0
+  args: [
+    -syntax-only
+  ]
 
-- id: packer-validate
+-
+  id: docker-packer-validate
   name: Validate Packer template(s)
   entry: hashicorp/packer:light validate
   language: docker_image
@@ -27,7 +32,47 @@
     -syntax-only
   ]
 
-- id: packer-validate-and-fix
+-
+  id: packer-fix
+  name: Fix Packer template(s) with backwards incompatibilities
+  entry: packer fix
+  language: system
+  types: [json]
+  files: ^packer.json$
+  always_run: false
+  verbose: false
+  pass_filenames: true
+  description: Attempts to fix incompatibilities in a template
+  minimum_pre_commit_version: 1.15.0
+
+-
+  id: docker-packer-fix
+  name: Fix Packer template(s) with backwards incompatibilities
+  entry: hashicorp/packer:light fix
+  language: docker_image
+  types: [json]
+  files: ^packer.json$
+  always_run: false
+  verbose: false
+  pass_filenames: true
+  description: Attempts to fix incompatibilities in a template
+  minimum_pre_commit_version: 1.15.0
+
+-
+  id: packer-validate-and-fix
+  name: Validate Packer template(s) and fix backwards incompatibilities
+  entry: packer fix -validate=true
+  language: system
+  types: [json]
+  files: ^packer.json$
+  always_run: false
+  verbose: false
+  pass_filenames: true
+  description: Validates and attempts to fix incompatibilities in a template
+  minimum_pre_commit_version: 1.15.0
+
+-
+  id: docker-packer-validate-and-fix
   name: Validate Packer template(s) and fix backwards incompatibilities
   entry: hashicorp/packer:light fix -validate=true
   language: docker_image

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,16 +1,37 @@
 ---
 
--   id: packer-validate
-    name: packer validate
-    entry: hashicorp/packer:light
-    language: docker_image
-    types: [json]
-    files: ^packer.json$
-    always_run: true
-    verbose: true
-    pass_filenames: true
-    description: TODO
-    minimum_pre_commit_version: 1.15.0
-    args:
-      - validate
-      - -syntax-only
+- id: packer-validate
+  name: Packer validate
+  entry: hashicorp/packer:light validate
+  language: docker_image
+  types: [json]
+  files: ^packer.json$
+  always_run: false
+  pass_filenames: true
+  description: Validates a template against builders, provisioners
+  minimum_pre_commit_version: 1.15.0
+  args: [
+    -syntax-only
+  ]
+
+- id: packer-fix
+  name: Packer fix
+  entry: hashicorp/packer:light fix
+  language: docker_image
+  types: [json]
+  files: ^packer.json$
+  always_run: false
+  pass_filenames: true
+  description: Attempts to fix incompatibilities in a template
+  minimum_pre_commit_version: 1.15.0
+
+- id: packer-fix-and-validate
+  name: Packer fix and validate
+  entry: hashicorp/packer:light fix -validate=true
+  language: docker_image
+  types: [json]
+  files: ^packer.json$
+  always_run: false
+  pass_filenames: true
+  description: Validates and attempts to fix incompatibilities in a template
+  minimum_pre_commit_version: 1.15.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+---
+
+-   id: packer-validate
+    name: packer validate
+    entry: hashicorp/packer:light
+    language: docker_image
+    types: [json]
+    files: ^packer.json$
+    always_run: true
+    verbose: true
+    pass_filenames: true
+    description: TODO
+    minimum_pre_commit_version: 1.15.0
+    args:
+      - validate
+      - -syntax-only

--- a/README.md
+++ b/README.md
@@ -1,0 +1,93 @@
+# `pre-commit-packer`
+
+> Packer-specific hooks for use with [pre-commit](https://pre-commit.com).
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Dependencies](#dependencies)
+- [Usage](#usage)
+  - [List of Hooks](#list-of-hooks)
+  - [Configuring Hooks](#configuring-hooks)
+  - [Using Docker](#using-docker)
+- [Notes](#notes)
+- [Author Information](#author-information)
+- [License](#license)
+
+## Requirements
+
+- `pre-commit` version `1.15.0` or newer
+
+## Dependencies
+
+- `packer` for hooks that are prefixed with `packer-`
+- `docker` for hooks that are prefixed with `docker-`
+
+## Usage
+
+The hooks in this repository can be used by adding the following stub to your `.pre-commit-config.yaml` file:
+
+```yaml
+---
+  -
+    repo: https://github.com/operatehappy/pre-commit-packer
+    rev: 1.0.0
+    hooks:
+      - id: packer-validate
+        files: packer*.json
+
+      - id: packer-fix
+        files: packer*.json
+
+      - id: packer-validate-and-fix
+        files: packer*.json
+```
+
+### List of Hooks
+
+- `packer-validate` wraps the `validate` [command](https://packer.io/docs/commands/validate.html) to parse Packer template(s) and check template configuration against any used builders, provisioners, and processors.
+
+- `packer-fix` wraps the `fix` [command](https://packer.io/docs/commands/fix.html) and attempts to fix (known) backwards incompatibilities in Packer template(s).
+
+- `packer-validate-and-fix` wraps the `fix` [command](https://packer.io/docs/commands/fix.html) and additionally validates the fixed Packer template(s).
+
+### Configuring Hooks
+
+All hooks accept the following configuration options:
+
+- `files` accepts a string (wildcards are supported) to define which file(s) the hook should target
+- `args` accepts an array with one or more valid command-specific CLI arguments
+
+The `args` configuration option is most useful with the `packer-validate` action as it allows for passing additional arguments such as a path to a variables file (`-var-file=packer.vars.json`). The upstream documentation for the `validate` command provides an overview of all [available options](https://packer.io/docs/commands/validate.html#options).
+
+### Using Docker
+
+The hooks provided by `pre-commit-packer` support invocation through a containerized version of the Packer [Docker Image](https://hub.docker.com/r/hashicorp/packer).
+
+This invocation defaults to the `light` [tag](https://hub.docker.com/r/hashicorp/packer/tags?page=1&name=light), but is otherwise functionally identical to a direct invocation via the `packer` binary.
+
+The Docker-specific hooks are prefixed with `docker-`:
+
+- `packer-fix` becomes `docker-packer-fix`
+- `packer-validate` becomes `docker-packer-validate`
+- `packer-validate-and-fix`  becomes `docker-packer-validate-and-fix`
+
+## Notes
+
+- In the [code example](#usage), the `1.0.0` version of `pre-commit-packer` has been selected. The [Releases](https://github.com/operatehappy/pre-commit-packer/releases) tab provides an overview of all available versions.
+
+## Author Information
+
+This repository is maintained by the contributors listed on [GitHub](https://github.com/operatehappy/pre-commit-packer/graphs/contributors)
+
+Development of this module was sponsored by [Operate Happy](https://github.com/operatehappy).
+
+## License
+
+Licensed under the Apache License, Version 2.0 (the "License").
+
+You may obtain a copy of the License at [apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an _"AS IS"_ basis, without WARRANTIES or conditions of any kind, either express or implied.
+
+See the License for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ All hooks accept the following configuration options:
 - `files` accepts a string (wildcards are supported) to define which file(s) the hook should target
 - `args` accepts an array with one or more valid command-specific CLI arguments
 
+The `files` configuration option defaults to `packer.json`
+
 The `args` configuration option is most useful with the `packer-validate` action as it allows for passing additional arguments such as a path to a variables file (`-var-file=packer.vars.json`). The upstream documentation for the `validate` command provides an overview of all [available options](https://packer.io/docs/commands/validate.html#options).
 
 ### Using Docker
@@ -68,8 +70,8 @@ This invocation defaults to the `light` [tag](https://hub.docker.com/r/hashicorp
 
 The Docker-specific hooks are prefixed with `docker-`:
 
-- `packer-fix` becomes `docker-packer-fix`
 - `packer-validate` becomes `docker-packer-validate`
+- `packer-fix` becomes `docker-packer-fix`
 - `packer-validate-and-fix`  becomes `docker-packer-validate-and-fix`
 
 ## Notes


### PR DESCRIPTION
This PR adds hooks for use with _Packer_.

Specifically: `packer fix` and `packer validate`; I've also added a Dockerized version of these same hooks to allow for use of these hooks in CI environments where `docker` is available, but `packer` is not (by default).

I believe the `docker` approach makes sense for GitHub Actions, as it allows the Actionized [.pre-commit-config.yaml](https://github.com/operatehappy/dotfiles-org/blob/master/.pre-commit-config.yaml) to be used, still.

Lots of documentation on this one (~ 10 lines more than _actual_ code), so please give that a look, as well.